### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:latest
+FROM rust:1-bookworm
 
 # Install cross-compilation tools and dependencies
 RUN dpkg --add-architecture arm64 && \


### PR DESCRIPTION
The issue is that the Docker setup is trying to use Debian Trixie (testing) which has package compatibility issues. The package libstdc++-11-dev:arm64 doesn't exist in Trixie, and several other packages are missing or have different names.