### PR TITLE
Update runner dependency to fix data races

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "edge-impulse-runner"
 version = "2.0.0"
-source = "git+https://github.com/edgeimpulse/edge-impulse-runner-rs.git?rev=c8cd1d8#c8cd1d812eb34a323d80218f8001ac4f25de8a45"
+source = "git+https://github.com/edgeimpulse/edge-impulse-runner-rs.git?rev=73b2add#73b2adde3aa886ec2a4daa8cab939340164acce3"
 dependencies = [
  "edge-impulse-ffi-rs",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ regex = "1.10.3"
 serde = "1.0"
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["rt-multi-thread"] }
-edge-impulse-runner = { git = "https://github.com/edgeimpulse/edge-impulse-runner-rs.git", rev = "c8cd1d8", default-features = false }
+edge-impulse-runner = { git = "https://github.com/edgeimpulse/edge-impulse-runner-rs.git", rev = "73b2add", default-features = false }
 tempfile = "3.10"
 
 [dev-dependencies]


### PR DESCRIPTION
Update runner to apply https://github.com/edgeimpulse/edge-impulse-runner-rs/pull/31 fixes:

> The Edge Impulse C++ SDK uses process-global state (ei_default_impulse, static buffers, TFLite interpreter) that is not thread-safe. When multiple callers invoke run_classifier() concurrently from different threads, the shared state is corrupted, causing garbled inference results or crashes.
>Add a process-level CLASSIFIER_LOCK mutex that serializes all FFI entry points: init, deinit, run_classifier, run_classifier_continuous, and run_inference. This ensures only one thread accesses the C++ SDK at a time.
