### PR TITLE
Add support to cross-compile with QNN acceleration and segfault fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "edge-impulse-runner"
 version = "2.0.0"
-source = "git+https://github.com/edgeimpulse/edge-impulse-runner-rs.git?rev=73b2add#73b2adde3aa886ec2a4daa8cab939340164acce3"
+source = "git+https://github.com/edgeimpulse/edge-impulse-runner-rs.git?rev=21449c2#21449c26f13f848235d9eaea42a3ced846732853"
 dependencies = [
  "edge-impulse-ffi-rs",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ regex = "1.10.3"
 serde = "1.0"
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["rt-multi-thread"] }
-edge-impulse-runner = { git = "https://github.com/edgeimpulse/edge-impulse-runner-rs.git", rev = "73b2add", default-features = false }
+edge-impulse-runner = { git = "https://github.com/edgeimpulse/edge-impulse-runner-rs.git", rev = "21449c2", default-features = false }
 tempfile = "3.10"
 
 [dev-dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,21 @@ RUN dpkg --add-architecture arm64 && \
     libatlas-base-dev \
     gfortran
 
+# Add QNN SDK for building with Qualcomm QNN support
+# Either provide QNN_SDK_URL to download at build time, or mount the SDK via docker-compose
+ARG QNN_SDK_VERSION=2.39.0.250926
+ARG QNN_SDK_URL=""
+RUN if [ -n "$QNN_SDK_URL" ]; then \
+        echo "Downloading QNN SDK from $QNN_SDK_URL..." && \
+        wget -q "$QNN_SDK_URL" -O /tmp/qnn-sdk.zip && \
+        unzip -q /tmp/qnn-sdk.zip -d /opt && \
+        rm /tmp/qnn-sdk.zip; \
+    else \
+        echo "No QNN_SDK_URL provided. Mount QNN SDK via docker-compose or set USE_QUALCOMM_QNN=0"; \
+    fi
+
+ENV QNN_SDK_ROOT=/opt/qairt/${QNN_SDK_VERSION}
+
 WORKDIR /app
 
 # Install rustfmt for aarch64 target

--- a/README.md
+++ b/README.md
@@ -463,6 +463,32 @@ docker-compose run --rm aarch64-build bash -c "
 "
 ```
 
+**Building with Qualcomm QNN Support:**
+
+To cross-compile with Qualcomm QNN (HTP/DSP) acceleration, provide the QNN SDK URL at Docker build time:
+
+```bash
+# Build Docker image with QNN SDK
+QNN_SDK_URL=https://softwarecenter.qualcomm.com/api/download/software/sdks/Qualcomm_AI_Runtime_Community/All/2.39.0.250926/v2.39.0.250926.zip \
+  docker compose build
+
+# Cross-compile with QNN enabled
+EI_MODEL=~/Downloads/your-model \
+  EI_ENGINE=tflite \
+  USE_FULL_TFLITE=1 \
+  USE_QUALCOMM_QNN=1 \
+  docker compose up aarch64-build
+```
+
+**Docker QNN Environment Variables:**
+
+| Variable | Where | Description |
+|---|---|---|
+| `QNN_SDK_URL` | Build arg | URL to download the QNN SDK zip at Docker build time |
+| `QNN_SDK_VERSION` | Build arg | QNN SDK version (default: `2.39.0.250926`) |
+| `QNN_SDK_ROOT` | Runtime env | Path to QNN SDK inside the container (default: `/opt/qairt/<version>`) |
+| `USE_QUALCOMM_QNN` | Runtime env | Set to `1` to enable QNN acceleration |
+
 The compiled plugin will be available at `target/aarch64-unknown-linux-gnu/release/libgstedgeimpulse.so`.
 
 ## Elements

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        - QNN_SDK_URL=${QNN_SDK_URL:-}
+        - QNN_SDK_VERSION=${QNN_SDK_VERSION:-2.39.0.250926}
     volumes:
       # Mount the current directory to /app
       - .:/app
@@ -24,6 +27,7 @@ services:
       - EI_ENGINE=${EI_ENGINE:-tflite}
       - USE_FULL_TFLITE=${USE_FULL_TFLITE:-}
       - USE_QUALCOMM_QNN=${USE_QUALCOMM_QNN:-}
+      - QNN_SDK_ROOT=${QNN_SDK_ROOT:-/opt/qairt/2.39.0.250926}
       - TARGET_LINUX_AARCH64=1
       - CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
       - CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++


### PR DESCRIPTION
Tweak cross-compile docker container to support QNN and fix segfault by updating runner with fix from https://github.com/edgeimpulse/edge-impulse-runner-rs/pull/32