### PR TITLE
Fix overlay not drawing in cross-variant pipelines

### DIFF
--- a/src/overlay/imp.rs
+++ b/src/overlay/imp.rs
@@ -59,7 +59,7 @@ use once_cell::sync::Lazy;
 use pangocairo::functions::*;
 use std::sync::Mutex;
 
-use crate::video::{VideoAnomalyMeta, VideoClassificationMeta};
+use crate::video::VideoAnomalyMeta;
 
 static CAT: Lazy<gst::DebugCategory> = Lazy::new(|| {
     let variant = env!("PLUGIN_VARIANT");
@@ -406,48 +406,66 @@ impl VideoFilterImpl for EdgeImpulseOverlay {
         );
 
         // Collect all metadata and data upfront to avoid borrow checker issues
-        let classification_data = frame.buffer().meta::<VideoClassificationMeta>().and_then(|meta| {
-            gst::debug!(
-                CAT,
-                obj = self.obj(),
-                "Found VideoClassificationMeta with {} params",
-                meta.params().len()
-            );
+        //
+        // In multi-variant pipelines, the VideoClassificationMeta on this buffer
+        // may have been registered by a different plugin variant (e.g. variant 35)
+        // than this overlay (e.g. variant 34). The typed lookup meta::<T>() matches
+        // by GType, so it would miss cross-variant metas. Instead, we iterate all
+        // metas and match by API name prefix. The struct layout is identical across
+        // variants (#[repr(C)] { meta: GstMeta, params: Vec<Structure> }).
+        let classification_data: Option<(String, f64)> = {
             let mut best_result: Option<(String, f64)> = None;
-            for param in meta.params() {
+            frame.buffer().iter_meta::<gst::Meta>().for_each(|meta| {
+                let api_name = meta.api().name().to_string();
+                if !api_name.starts_with("VideoClassificationMetaAPI") {
+                    return;
+                }
+                // Safety: all VideoClassificationMeta variants share the same
+                // #[repr(C)] layout: { meta: GstMeta, params: Vec<Structure> }.
+                let raw_meta = unsafe {
+                    &*(meta.as_ptr() as *const crate::video::meta::imp::VideoClassificationMeta)
+                };
                 gst::debug!(
                     CAT,
                     obj = self.obj(),
-                    "Processing classification param: name={}, has_field_label={}, has_field_confidence={}",
-                    param.name(),
-                    param.has_field("label"),
-                    param.has_field("confidence")
+                    "Found VideoClassificationMeta (api={}) with {} params",
+                    api_name,
+                    raw_meta.params.len()
                 );
-                if param.name() != "classification" {
-                    continue;
-                }
-
-                if let (Ok(label), Ok(confidence)) =
-                    (param.get::<String>("label"), param.get::<f64>("confidence"))
-                {
+                for param in &raw_meta.params {
                     gst::debug!(
                         CAT,
                         obj = self.obj(),
-                        "Found classification result: {} ({:.1}%)",
-                        label,
-                        confidence * 100.0
+                        "Processing classification param: name={}, has_field_label={}, has_field_confidence={}",
+                        param.name(),
+                        param.has_field("label"),
+                        param.has_field("confidence")
                     );
-                    match best_result {
-                        None => best_result = Some((label, confidence)),
-                        Some((_, prev_conf)) if confidence > prev_conf => {
-                            best_result = Some((label, confidence))
+                    if param.name() != "classification" {
+                        continue;
+                    }
+                    if let (Ok(label), Ok(confidence)) =
+                        (param.get::<String>("label"), param.get::<f64>("confidence"))
+                    {
+                        gst::debug!(
+                            CAT,
+                            obj = self.obj(),
+                            "Found classification result: {} ({:.1}%)",
+                            label,
+                            confidence * 100.0
+                        );
+                        match best_result {
+                            None => best_result = Some((label, confidence)),
+                            Some((_, prev_conf)) if confidence > prev_conf => {
+                                best_result = Some((label, confidence))
+                            }
+                            _ => {}
                         }
-                        _ => {}
                     }
                 }
-            }
+            });
             best_result
-        });
+        };
 
         let anomaly_data = frame.buffer().meta::<VideoAnomalyMeta>().map(|meta| {
             gst::debug!(

--- a/src/video/imp.rs
+++ b/src/video/imp.rs
@@ -580,6 +580,19 @@ impl BaseTransformImpl for EdgeImpulseVideoInfer {
     /// Don't transform in-place even in passthrough mode
     const TRANSFORM_IP_ON_PASSTHROUGH: bool = false;
 
+    // GStreamer's default transform_meta drops metas whose API type has tags
+    // (e.g. VideoRegionOfInterestMeta with "video"/"size" tags). In multi-model
+    // pipelines the upstream element's ROI metadata must survive through this
+    // element's NeverInPlace transform so downstream overlays can draw them.
+    fn transform_meta<'a>(
+        &self,
+        _outbuf: &mut gst::BufferRef,
+        _meta: gst::MetaRef<'a, gst::Meta>,
+        _inbuf: &'a gst::BufferRef,
+    ) -> bool {
+        true
+    }
+
     /// Get the size of one unit for the given caps
     fn unit_size(&self, caps: &gst::Caps) -> Option<usize> {
         // Parse the caps into video info

--- a/src/video/meta.rs
+++ b/src/video/meta.rs
@@ -149,7 +149,7 @@ impl fmt::Debug for VideoAnomalyMeta {
 }
 
 // Actual unsafe implementation of the meta
-mod imp {
+pub(crate) mod imp {
     use super::*;
     use glib::translate::*;
     use gstreamer as gst;
@@ -165,7 +165,7 @@ mod imp {
     #[repr(C)]
     pub struct VideoClassificationMeta {
         pub(super) meta: gst::ffi::GstMeta,
-        pub(super) params: Vec<gst::Structure>,
+        pub(crate) params: Vec<gst::Structure>,
     }
 
     // This is the C type that is actually stored as meta inside the buffers

--- a/src/video/mod.rs
+++ b/src/video/mod.rs
@@ -1,5 +1,5 @@
 mod imp;
-mod meta;
+pub(crate) mod meta;
 
 use gstreamer as gst;
 use gstreamer::glib;


### PR DESCRIPTION
  In multi-variant pipelines (e.g. videoinfer_34 → videoinfer_35 →
  overlay_34), two bugs prevented the overlay from rendering:

  1. VideoRegionOfInterestMeta (bounding boxes) was silently dropped when passing through a downstream NeverInPlace videoinfer element. GStreamer's default transform_meta rejects metas with API tags (video, size), while tagless custom metas survived. Override transform_meta to preserve all upstream metadata.

  2. The overlay's typed meta::<VideoClassificationMeta>() lookup matched by GType, so overlay variant 34 could never find classification metadata registered by variant 35. Replace with name-prefix iteration over all buffer metas and unsafe cast to the shared repr(C) layout.